### PR TITLE
fix: restructure to be able to publish owasp as well

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,6 +66,11 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: clean dependencyCheckAnalyze
+      - name: Upload owasp-report results
+        uses: actions/upload-artifact@v2
+        with:
+          name: owasp-reports
+          path: build/reports/owasp
 
   release:
     name: Release
@@ -87,7 +92,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: assemble -x test -x integrationTest
-          wrapper-cache-enabled: true
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
@@ -120,7 +124,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: clean assemble dockerCreateDockerfile -x test -x integrationTest
-          wrapper-cache-enabled: true
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -155,11 +158,15 @@ jobs:
         with:
           name: documentation
           path: build/documentation
+      - name: Download owasp reports
+        uses: actions/download-artifact@v2
+        with:
+          name: owasp-reports
+          path: build/reports/owasp
       - name: Build package
         uses: gradle/gradle-build-action@v2
         with:
           arguments: aggregateDocumentation
-          wrapper-cache-enabled: true
         env:
           revnumber: ${{ needs.release.outputs.revnumber }}
       - name: Publish documentation

--- a/buildSrc/src/main/kotlin/org/javafreedom/documentation/documentation-consumer-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/org/javafreedom/documentation/documentation-consumer-conventions.gradle.kts
@@ -27,7 +27,6 @@ tasks.register("aggregateReports") {
     dependsOn(testReportTask)
     dependsOn(jacocoReportTask)
     dependsOn(detektReportTask)
-    dependsOn(dependencyCheckTask)
 
     doLast {
         val targetDir = buildDir.resolve("documentation").toPath()
@@ -51,13 +50,6 @@ tasks.register("aggregateReports") {
             into(targetDir.resolve("detekt"))
             from(detektReportTask.map { task -> task.outputs })
         }
-
-        copy {
-            into(targetDir.resolve("owasp"))
-            project.extensions.findByType<DependencyCheckExtension>()?.let {
-                from(it.outputDirectory)
-            }
-        }
     }
 }
 
@@ -69,6 +61,13 @@ tasks.register("aggregateDocumentation") {
 
     doLast {
         val targetDir = buildDir.resolve("documentation").toPath()
+
+        copy {
+            into(targetDir.resolve("owasp"))
+            project.extensions.findByType<DependencyCheckExtension>()?.let {
+                from(it.outputDirectory)
+            }
+        }
 
         copy {
             into(targetDir.resolve("pages"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 github_org=triplem
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+org.gradle.caching=true
 
 kotlinVersion=1.6.10
 junitVersion=5.8.2


### PR DESCRIPTION
Sonarcloud does not accept the owasp report, therefor we do publish this report on the page